### PR TITLE
Ability to use NeoPixel leds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,45 @@ jobs:
           pip install --upgrade platformio
       
       - run: PLATFORMIO_SRC_DIR="examples/TrafficLightJson" PIO_BOARD=${{ matrix.board }} pio run -e ${{ matrix.env }}
+
+  platformio-neopixel:
+    name: "pio:${{ matrix.env }}:${{ matrix.board }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env: ci-neopixel
+            board: esp32dev
+          - env: ci-neopixel
+            board: esp32-s2-saola-1
+          - env: ci-neopixel
+            board: esp32-s3-devkitc-1
+          - env: ci-neopixel
+            board: esp32-c3-devkitc-02
+          - env: ci-neopixel
+            board: esp32-c6-devkitc-1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-pio
+          path: |
+            ~/.cache/pip
+            ~/.platformio
+
+      - name: Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+      
+      - run: PLATFORMIO_SRC_DIR="examples/TrafficLightNeoPixel" PIO_BOARD=${{ matrix.board }} pio run -e ${{ matrix.env }}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@
 [![PlatformIO Registry](https://badges.registry.platformio.org/packages/mathieucarbou/library/MycilaTrafficLight.svg)](https://registry.platformio.org/libraries/mathieucarbou/MycilaTrafficLight)
 
 ESP32 / Arduino Library for Traffic Light LEDs
+
+- Supports standard GPIO leds
+- Supports NeoPixel leds (addition from [@hallard](https://github.com/hallard))
+
+**NeoPixel example:**
+
+```cpp
+// Argument 1 = pin number (most are valid)
+// Argument 2 = Number of pixels in NeoPixel strip (default 3 if omited)
+// Argument 3 = Pixel type flags defaut if omited ( NEO_GRB + NEO_KHZ800 )
+lights.begin(NEOPIXEL_PIN, NEOPIXEL_COUNT, NEOPIXEL_FLAGS);
+
+// Set BRIGHTNESS to about 1/5 (0.0 to 1.0)
+lights.setBrightness(0.2f);
+
+lights.setAllOff();
+lights.setGreen(true);
+lights.setYellow(true);
+lights.setRed(true);
+// [...]
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,24 @@
 [![PlatformIO Registry](https://badges.registry.platformio.org/packages/mathieucarbou/library/MycilaTrafficLight.svg)](https://registry.platformio.org/libraries/mathieucarbou/MycilaTrafficLight)
 
 ESP32 / Arduino Library for Traffic Light LEDs
+
+- Supports standard GPIO leds
+- Supports NeoPixel leds (addition from [@hallard](https://github.com/hallard))
+
+**NeoPixel example:**
+
+```cpp
+// Argument 1 = pin number (most are valid)
+// Argument 2 = Number of pixels in NeoPixel strip (default 3 if omited)
+// Argument 3 = Pixel type flags defaut if omited ( NEO_GRB + NEO_KHZ800 )
+lights.begin(NEOPIXEL_PIN, NEOPIXEL_COUNT, NEOPIXEL_FLAGS);
+
+// Set BRIGHTNESS to about 1/5 (0.0 to 1.0)
+lights.setBrightness(0.2f);
+
+lights.setAllOff();
+lights.setGreen(true);
+lights.setYellow(true);
+lights.setRed(true);
+// [...]
+```

--- a/examples/TrafficLightNeoPixel/TrafficLightNeoPixel.ino
+++ b/examples/TrafficLightNeoPixel/TrafficLightNeoPixel.ino
@@ -1,0 +1,55 @@
+#include <Arduino.h>
+#include <MycilaTrafficLight.h>
+
+// Which pin is connected to the NeoPixels?
+constexpr uint16_t NEOPIXEL_PIN = 4;
+
+// How many NeoPixels
+constexpr uint16_t NEOPIXEL_COUNT = 3;
+
+// Pixel type flags, add together as needed:
+//   NEO_KHZ800  800 KHz bitstream (most NeoPixel products w/WS2812 LEDs)
+//   NEO_KHZ400  400 KHz (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
+//   NEO_GRB     Pixels are wired for GRB bitstream (most NeoPixel products)
+//   NEO_RGB     Pixels are wired for RGB bitstream (v1 FLORA pixels, not v2)
+//   NEO_RGBW    Pixels are wired for RGBW bitstream (NeoPixel RGBW products)
+constexpr neoPixelType NEOPIXEL_FLAGS = NEO_GRB + NEO_KHZ800;
+
+Mycila::TrafficLight lights;
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial)
+    continue;
+
+  // Argument 1 = pin number (most are valid)
+  // Argument 2 = Number of pixels in NeoPixel strip (default 3 if omited)
+  // Argument 3 = Pixel type flags defaut if omited ( NEO_GRB + NEO_KHZ800 )
+  lights.begin(NEOPIXEL_PIN, NEOPIXEL_COUNT, NEOPIXEL_FLAGS);
+
+  // Set BRIGHTNESS to about 1/5 (0.0 to 1.0)
+  lights.setBrightness(0.2f);
+  lights.setAllOff();
+}
+
+void loop() {
+
+  // Simple Traffic Light
+  lights.setGreen(true);
+  delay(3000);
+
+  lights.setAllOff();
+  delay(200);
+
+  lights.setYellow(true);
+  delay(1000);
+
+  lights.setAllOff();
+  delay(200);
+
+  lights.setRed(true);
+  delay(3000);
+
+  lights.setAllOff();
+  delay(200);
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,8 @@
 [platformio]
 lib_dir = .
 ; src_dir = examples/TrafficLight
-src_dir = examples/TrafficLightJson
+; src_dir = examples/TrafficLightJson
+src_dir = examples/TrafficLightNeoPixel
 
 [env]
 framework = arduino
@@ -42,6 +43,16 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 ; board = esp32-s3-devkitc-1
 ; board = esp32-c6-devkitc-1
 
+[env:neopixel]
+lib_deps = 
+  adafruit/Adafruit NeoPixel @ 1.12.3
+build_flags = 
+  ${dev.build_flags}
+  -D MYCILA_NEOPIXEL_SUPPORT
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10-rc1/platform-espressif32.zip
+; board = esp32-s3-devkitc-1
+; board = esp32-c6-devkitc-1
+
 ;  CI
 
 [ci]
@@ -68,5 +79,14 @@ lib_deps =
 build_flags = 
   ${ci.build_flags}
   -D MYCILA_JSON_SUPPORT
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10-rc1/platform-espressif32.zip
+board = ${sysenv.PIO_BOARD}
+
+[env:ci-neopixel]
+lib_deps = 
+  adafruit/Adafruit NeoPixel @ 1.12.3
+build_flags = 
+  ${dev.build_flags}
+  -D MYCILA_NEOPIXEL_SUPPORT
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10-rc1/platform-espressif32.zip
 board = ${sysenv.PIO_BOARD}

--- a/src/MycilaTrafficLight.cpp
+++ b/src/MycilaTrafficLight.cpp
@@ -69,6 +69,31 @@ bool Mycila::TrafficLight::begin(const int8_t greenPin, const int8_t yellowPin, 
   return true;
 }
 
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+bool Mycila::TrafficLight::begin(const int8_t neoPin, const size_t neoCount, const neoPixelType neoType) {
+  if (_strip != nullptr) {
+    LOGW(TAG, "Traffic light already enabled");
+    return false;
+  }
+
+  if (!GPIO_IS_VALID_OUTPUT_GPIO(neoPin)) {
+    LOGE(TAG, "Invalid NeoPixel LED pin: %" PRId8, neoPin);
+    return false;
+  }
+
+  if (neoCount < 3) {
+    LOGE(TAG, "Not Enough NeoPixel LED count: %" PRId16, neoCount);
+    return false;
+  }
+
+  LOGI(TAG, "Enable %" PRId16 " NeoPixel LED on pin: %" PRId8, neoCount, neoPin);
+  _strip = new Adafruit_NeoPixel(neoCount, neoPin, neoType);
+  _strip->begin();
+
+  return true;
+}
+#endif
+
 void Mycila::TrafficLight::end() {
   set(State::OFF, State::OFF, State::OFF);
 
@@ -81,6 +106,23 @@ void Mycila::TrafficLight::end() {
     _yellowPin = GPIO_NUM_NC;
     _redPin = GPIO_NUM_NC;
   }
+
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+  if (_strip != nullptr) {
+    digitalWrite(_strip->getPin(), LOW);
+    _strip->setBrightness(0);
+    delete _strip;
+    _strip = nullptr;
+  }
+#endif
+}
+
+bool Mycila::TrafficLight::isEnabled() const {
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+  return _gpioEnabled || _strip != nullptr;
+#else
+  return _gpioEnabled;
+#endif
 }
 
 void Mycila::TrafficLight::set(State green, State yellow, State red) {
@@ -96,6 +138,23 @@ void Mycila::TrafficLight::set(State green, State yellow, State red) {
     digitalWrite(_yellowPin, _yellow ? HIGH : LOW);
     digitalWrite(_redPin, _red ? HIGH : LOW);
   }
+
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+  if (_strip != nullptr) {
+    _strip->setPixelColor(0, _green ? _strip->Color(0, 255, 0) : _strip->Color(0, 0, 0));
+    _strip->setPixelColor(1, _yellow ? _strip->Color(128, 128, 0) : _strip->Color(0, 0, 0));
+    _strip->setPixelColor(2, _red ? _strip->Color(255, 0, 0) : _strip->Color(0, 0, 0));
+    _strip->show();
+  }
+#endif
+}
+
+void Mycila::TrafficLight::setBrightness(const float brightness) {
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+  if (_strip != nullptr) {
+    _strip->setBrightness(static_cast<uint8_t>(brightness * 255));
+  }
+#endif
 }
 
 #ifdef MYCILA_JSON_SUPPORT

--- a/src/MycilaTrafficLight.h
+++ b/src/MycilaTrafficLight.h
@@ -11,6 +11,10 @@
   #include <ArduinoJson.h>
 #endif
 
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+  #include <Adafruit_NeoPixel.h>
+#endif
+
 #define MYCILA_TRAFFIC_LIGHT_VERSION          "1.0.0"
 #define MYCILA_TRAFFIC_LIGHT_VERSION_MAJOR    1
 #define MYCILA_TRAFFIC_LIGHT_VERSION_MINOR    0
@@ -27,10 +31,15 @@ namespace Mycila {
 
     public:
       bool begin(const int8_t greenPin, const int8_t yellowPin, const int8_t redPin);
+
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+      bool begin(const int8_t neoPin, const size_t neoCount = 3, const neoPixelType neoType = NEO_GRB + NEO_KHZ800);
+#endif
+
       void end();
 
       // indicates whether the traffic light is enabled with backed GPIO pins
-      bool isEnabled() const { return _gpioEnabled; }
+      bool isEnabled() const;
 
       inline void setAllOn() { set(State::ON, State::ON, State::ON); }
       inline void setAllOff() { set(State::OFF, State::OFF, State::OFF); }
@@ -39,6 +48,10 @@ namespace Mycila {
       inline void setYellow(bool state) { set(State::NONE, state ? State::ON : State::OFF, State::NONE); }
       inline void setRed(bool state) { set(State::NONE, State::NONE, state ? State::ON : State::OFF); }
       void set(State green, State yellow, State red);
+
+      // set the brightness of the NeoPixel strip
+      // No-op for GPIO pins
+      void setBrightness(const float brightness);
 
       State getGreen() const { return _green ? State::ON : State::OFF; }
       State getYellow() const { return _yellow ? State::ON : State::OFF; }
@@ -71,5 +84,9 @@ namespace Mycila {
       gpio_num_t _greenPin = GPIO_NUM_NC;
       gpio_num_t _yellowPin = GPIO_NUM_NC;
       gpio_num_t _redPin = GPIO_NUM_NC;
+
+#ifdef MYCILA_NEOPIXEL_SUPPORT
+      Adafruit_NeoPixel* _strip = nullptr;
+#endif
   };
 } // namespace Mycila


### PR DESCRIPTION
All by boards uses neopixel, this one allow to use them, may be implemented into yasolr :-)

- Added NeoPixel possible use (even both same time)
- Added NeoPixel Example
- Added Adafruit NeoPixel Library

For now straight compatibility just drive one color on each led Green, Yellow and Red, if needed I'll add ability to traffic light only with one Led.